### PR TITLE
Update `.emitParticles()`

### DIFF
--- a/src/RailUtil/InstanceUtil/init.luau
+++ b/src/RailUtil/InstanceUtil/init.luau
@@ -657,28 +657,23 @@ end
 	```
 ]=]
 function InstanceUtil.emitParticles(parent: Instance, emitCount: number?)
+	local function Emit(emitter: ParticleEmitter)
+		emitter:Emit(emitCount or emitter:GetAttribute("EmitCount") :: number? or 10)
+	end
+
 	if parent:IsA("ParticleEmitter") then
-		local PE: ParticleEmitter = parent
-		local function Emit()
-			PE:Emit(emitCount or PE:GetAttribute("EmitCount") :: number? or 10)
-			local EmitDuration: number? = PE:GetAttribute("EmitDuration") :: any
-			if typeof(EmitDuration) == "number" then
-				PE.Enabled = true
-				task.delay(EmitDuration, function()
-					PE.Enabled = false
+		Emit(parent :: ParticleEmitter)
+	else
+		for _, emitter in parent:QueryDescendants("ParticleEmitter") do
+			local emitDelay: number? = emitter:GetAttribute("EmitDelay") :: number
+			if emitDelay and typeof(emitDelay) == "number" then
+				task.delay(emitDelay, function()
+					Emit(emitter :: ParticleEmitter)
 				end)
+			else
+				Emit(emitter :: ParticleEmitter)
 			end
 		end
-
-		local EmitDelay: number? = PE:GetAttribute("EmitDelay") :: any
-		if typeof(EmitDelay) == "number" then
-			task.delay(EmitDelay, Emit)
-		else
-			Emit()
-		end
-	end
-	for _, child in pairs(parent:GetChildren()) do
-		InstanceUtil.emitParticles(child)
 	end
 end
 

--- a/src/RailUtil/InstanceUtil/init.luau
+++ b/src/RailUtil/InstanceUtil/init.luau
@@ -652,29 +652,36 @@ end
 
 	@param parent	 -- The Instance to search Particles for
 	@param emitCount -- The number of particles to emit
+	@return {thread?} -- A table of delayed threads if any of the emitters had EmitDelay.
+		Useful for cleaning up if needed.
 	```lua
 	InstanceUtil.emitParticles(workspace.Effect)
 	```
 ]=]
-function InstanceUtil.emitParticles(parent: Instance, emitCount: number?)
+function InstanceUtil.emitParticles(parent: Instance, emitCount: number?): {thread?}
+	local delayedThreads: {thread?} = {}
 	local function Emit(emitter: ParticleEmitter)
-		emitter:Emit(emitCount or emitter:GetAttribute("EmitCount") :: number? or 10)
+		local emitDelay: number? = emitter:GetAttribute("EmitDelay") :: number
+		local emitCount: number? = emitCount or emitter:GetAttribute("EmitCount") :: number? or 10
+		if emitDelay and typeof(emitDelay) == "number" then
+			local delayedThread = task.delay(emitDelay, function()
+				emitter:Emit(emitCount)
+			end)
+			table.insert(delayedThreads, delayedThread)
+		else
+			emitter:Emit(emitCount)
+		end
 	end
 
 	if parent:IsA("ParticleEmitter") then
 		Emit(parent :: ParticleEmitter)
 	else
 		for _, emitter in parent:QueryDescendants("ParticleEmitter") do
-			local emitDelay: number? = emitter:GetAttribute("EmitDelay") :: number
-			if emitDelay and typeof(emitDelay) == "number" then
-				task.delay(emitDelay, function()
-					Emit(emitter :: ParticleEmitter)
-				end)
-			else
-				Emit(emitter :: ParticleEmitter)
-			end
+			Emit(emitter :: ParticleEmitter)
 		end
 	end
+
+	return delayedThreads
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
- Solve issue with emit count argument not passing to descending ParticleEmitters
- Removed EmitDuration functionality since it serves no purpose considering `:Emit()` only emits at the time of call
- Return array of delayed threads for emitters with EmitDelay attribute in case the user wants to clean them up (use case: cancel those threads in case emitter no longer exists before the delay time elapses)